### PR TITLE
Fix wrong backup directory var name in apt module (#73840)

### DIFF
--- a/changelogs/fragments/73840_apt-policy-rc-d.yml
+++ b/changelogs/fragments/73840_apt-policy-rc-d.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >-
+    apt - fix policy_rc_d parameter throwing an exception when restoring
+    original file (https://github.com/ansible/ansible/issues/66211)

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -428,7 +428,7 @@ class PolicyRcD(object):
             try:
                 shutil.move(os.path.join(self.backup_dir, 'policy-rc.d'),
                             '/usr/sbin/policy-rc.d')
-                os.rmdir(self.tmpdir_name)
+                os.rmdir(self.backup_dir)
             except Exception:
                 self.m.fail_json(msg="Fail to move back %s to /usr/sbin/policy-rc.d"
                                      % os.path.join(self.backup_dir, 'policy-rc.d'))


### PR DESCRIPTION
* Fix wrong backup directory var name in apt module

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
